### PR TITLE
replace twig-language-server with twiggy-language-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
+# zed-twig
+*.wasm
+/grammars
+
+# Rust
 /target
-
-
-# Added by cargo
-#
-# already existing elements were commented out
-
-#/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "zed-twig"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "zed_extension_api",
 ]

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is a zed extension that enables intellisense and syntax highlighting for th
 
 ## Credits
 
-This extension is based on:
+This extension uses:
 
-- https://github.com/gbprod/tree-sitter-twig for the syntax highlighting
-- https://github.com/kaermorchen/twig-language-server for the intellisense
+- https://github.com/gbprod/tree-sitter-twig for syntax highlighting
+- https://github.com/moetelo/twiggy for the language-server
 
 Contributions are welcome!

--- a/extension.toml
+++ b/extension.toml
@@ -7,8 +7,8 @@ description = "Syntax highlighting and Intellisense for Twig in Zed"
 repository = "https://github.com/YussufSassi/zed-twig"
 
 [grammars.twig]
-repository = "https://github.com/gbprod/tree-sitter-twig"
-commit = "eaf80e6af969e25993576477a9dbdba3e48c1305"
+repository = "https://github.com/jannisborgers/tree-sitter-twig"
+commit = "723926cff978453c40ee11ca8046de0cb248873c"
 
 [language_servers.twiggy-language-server]
 name = "Twiggy Language Server"

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "twig"
 name = "Twig"
-version = "0.1.1"
+version = "0.2.0"
 schema_version = 1
 authors = ["Yussuf Sassi <yussuf@tuta.io>"]
 description = "Syntax highlighting and Intellisense for Twig in Zed"
@@ -10,7 +10,6 @@ repository = "https://github.com/YussufSassi/zed-twig"
 repository = "https://github.com/gbprod/tree-sitter-twig"
 commit = "eaf80e6af969e25993576477a9dbdba3e48c1305"
 
-
-[language_servers.twig-language-server]
-name = "Twig Language Server"
+[language_servers.twiggy-language-server]
+name = "Twiggy Language Server"
 language = "Twig"

--- a/grammars/twig.toml
+++ b/grammars/twig.toml
@@ -1,2 +1,0 @@
-repository = "https://github.com/gbprod/tree-sitter-twig"
-commit = "eaf80e6af969e25993576477a9dbdba3e48c1305"

--- a/languages/twig/brackets.scm
+++ b/languages/twig/brackets.scm
@@ -1,2 +1,3 @@
 ("{{" @open "}}" @close)
 ("{%" @open "%}" @close)
+("\"" @open "\"" @close)

--- a/languages/twig/brackets.scm
+++ b/languages/twig/brackets.scm
@@ -1,0 +1,2 @@
+("{{" @open "}}" @close)
+("{%" @open "%}" @close)

--- a/languages/twig/config.toml
+++ b/languages/twig/config.toml
@@ -1,13 +1,20 @@
 name = "Twig"
 grammar = "twig"
 path_suffixes = ["html.twig", "twig", "twig.html"]
-autoclose_before = ">})"
+autoclose_before = "}])>"
 block_comment = ["{# ", " #}"]
 brackets = [
     { start = "{{", end = "}}", close = true, newline = true },
     { start = "{%", end = "%}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
+    # Single { would take precedence over {{ and {%
+    # Idea: Don’t use when inside whitespace (not currently captured by tree-sitter node)
+    # { start = "{", end = "}", close = true, newline = true, not_in = [""] },
+    { start = "'", end = "'", close = true, newline = false, not_in = [
+        "comment",
+        "string",
+    ] },
     { start = "\"", end = "\"", close = true, newline = false, not_in = [
         "comment",
         "string",

--- a/languages/twig/highlights.scm
+++ b/languages/twig/highlights.scm
@@ -17,6 +17,7 @@
 (repeat) @repeat
 (method) @method
 (parameter) @parameter
+(hash_key) @property
 
 [
     "{{"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 use std::{env, fs};
 use zed_extension_api::{self as zed, Result};
 
-const SERVER_PATH: &str = "node_modules/twig-language-server/out/index.js";
-const PACKAGE_NAME: &str = "twig-language-server";
+const SERVER_PATH: &str = "node_modules/twiggy-language-server/dist/server.js";
+const PACKAGE_NAME: &str = "twiggy-language-server";
 
 struct TwigExtension {
     did_find_server: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ impl TwigExtension {
             &language_server_id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
-        let version = zed::npm_package_latest_version(PACKAGE_NAME)?;
+        let version = "0.17.0".to_string();
 
         if !server_exists
             || zed::npm_package_installed_version(PACKAGE_NAME)?.as_ref() != Some(&version)


### PR DESCRIPTION
This replaces the old `twig-language-server` from the **Modern Twig** VSCode extension with the more up-to-date `twiggy-language-server` from the **Twiggy** VSCode extension, while keeping  `gbprod/tree-sitter-twig` as the extension’s grammar and fixes the extension’s failure to install and run the language server.

PS: I also put the `grammars` directory and `extension.wasm` in .gitignore, they are generated by the extension on install. I’m not sure about excluding the grammar, but the .wasm is excluded in other extensions, so I put it there.